### PR TITLE
chore: skip c tests if env var is present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,11 @@ add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})
 
 set(PARAMETERS "-warnings")
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
-add_subdirectory("test/c")
+IF (DEFINED ENV{SKIP_SUBSTRAIT_C_TESTS})
+    message(STATUS "Skipping substrait c tests")
+ELSE()
+    add_subdirectory("test/c")
+ENDIF()
 
 install(
   TARGETS ${EXTENSION_NAME}


### PR DESCRIPTION
While integrating this extension as an out of tree extension using https://github.com/duckdb/duckdb/tree/main/extension#remote-github-repo and building duckdb I found that the C tests don't compile properly: the submodules aren't checked out in this path. 

This was the simplest and cleanest way I could find to skip the compilation of the C tests when compiling substrait directly in duckdb (these tests aren't run in that path anyways and the tests still are run as part of normal CI)