### PR TITLE
fix: map substrait extract(UNIX_TIME) to date_part('epoch')

### DIFF
--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -607,12 +607,24 @@ unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformScalarFunctionExpr(cons
 		D_ASSERT(enum_expressions.size() == 1);
 		auto &subfield = enum_expressions[0];
 		// Substrait's UNIX_TIME specifier (epoch seconds, return type i64) has no
-		// DuckDB date_part equivalent of that name. Map it to date_part('epoch'),
-		// which yields DOUBLE, and cast back to BIGINT to honor the standard's i64.
-		if (subfield == "UNIX_TIME") {
+		// DuckDB date_part equivalent of that name. Map it to date_part('epoch') and
+		// floor before casting, to honor the standard's "elapsed whole seconds".
+		if (StringUtil::CIEquals(subfield, "UNIX_TIME")) {
+			// The precision_timestamp_tz impl carries a trailing timezone argument.
+			// UNIX_TIME is timezone-independent, so drop it instead of emitting an
+			// unbindable three-argument date_part.
+			if (children.size() > 1) {
+				children.resize(1);
+			}
 			children.insert(children.begin(), make_uniq<ConstantExpression>(Value("epoch")));
-			auto call = make_uniq<FunctionExpression>("date_part", std::move(children));
-			return make_uniq<CastExpression>(LogicalType::BIGINT, std::move(call));
+			auto call = make_uniq<FunctionExpression>(RemapFunctionName(function_name), std::move(children));
+			// date_part('epoch') returns DOUBLE and DuckDB's DOUBLE->BIGINT cast rounds
+			// half-to-even, which would report one second too many for any sub-second
+			// timestamp. UNIX_TIME is elapsed whole seconds, so floor explicitly.
+			vector<unique_ptr<ParsedExpression>> floor_args;
+			floor_args.push_back(std::move(call));
+			auto floored = make_uniq<FunctionExpression>("floor", std::move(floor_args));
+			return make_uniq<CastExpression>(LogicalType::BIGINT, std::move(floored));
 		}
 		VerifyCorrectExtractSubfield(subfield);
 		auto constant_expression = make_uniq<ConstantExpression>(Value(subfield));

--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -606,6 +606,14 @@ unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformScalarFunctionExpr(cons
 	} else if (function_name == "extract") {
 		D_ASSERT(enum_expressions.size() == 1);
 		auto &subfield = enum_expressions[0];
+		// Substrait's UNIX_TIME specifier (epoch seconds, return type i64) has no
+		// DuckDB date_part equivalent of that name. Map it to date_part('epoch'),
+		// which yields DOUBLE, and cast back to BIGINT to honor the standard's i64.
+		if (subfield == "UNIX_TIME") {
+			children.insert(children.begin(), make_uniq<ConstantExpression>(Value("epoch")));
+			auto call = make_uniq<FunctionExpression>("date_part", std::move(children));
+			return make_uniq<CastExpression>(LogicalType::BIGINT, std::move(call));
+		}
 		VerifyCorrectExtractSubfield(subfield);
 		auto constant_expression = make_uniq<ConstantExpression>(Value(subfield));
 		children.insert(children.begin(), std::move(constant_expression));

--- a/test/sql/test_substrait_extract_unix_time.test
+++ b/test/sql/test_substrait_extract_unix_time.test
@@ -1,0 +1,70 @@
+# name: test/sql/test_substrait_extract_unix_time.test
+# description: Consumer-side coverage for Substrait extract(UNIX_TIME) -> date_part('epoch')
+# group: [sql]
+
+require substrait
+
+require json
+
+statement ok
+PRAGMA enable_verification
+
+# The producer can never emit UNIX_TIME: `epoch` is not in to_substrait.cpp's
+# valid_extract_subfields, so get_substrait_json only ever drives the other
+# specifiers. The only way to reach the consumer's UNIX_TIME branch is a plan
+# that carries the enum, so synthesize one from a normal extract and rewrite
+# the enum in the JSON. Lowercase `unix_time` also pins the case-insensitive
+# match (the producer emits lowercase enum values).
+
+statement ok
+CREATE TABLE t (ts TIMESTAMP);
+
+# Values chosen so floor(epoch) differs from round(epoch): DuckDB's DOUBLE->BIGINT
+# cast rounds half-to-even, so .75 -> +1 and 1.5 -> +2 and -0.5 -> 0 without an
+# explicit floor. UNIX_TIME is elapsed whole seconds, so the flooring is the point.
+statement ok
+INSERT INTO t VALUES
+    ('1970-01-01 00:00:00.75'),
+    ('1970-01-01 00:00:01.5'),
+    ('1969-12-31 23:59:59.5'),
+    ('2021-08-03 11:59:44.75');
+
+statement ok
+SET VARIABLE plan_unix = (
+    SELECT replace(json, '"enum":"second"', '"enum":"unix_time"')
+    FROM get_substrait_json('SELECT extract(second FROM ts) AS r FROM t')
+);
+
+query I
+SELECT * FROM from_substrait_json(getvariable('plan_unix')) ORDER BY 1
+----
+-1
+0
+1
+1627991984
+
+# Substrait's precision_timestamp_tz impl signature is
+# extract(component, x, timezone: string) -- the timezone is a value argument, so
+# it lands in `children`. UNIX_TIME is timezone-independent, so the consumer must
+# drop it; otherwise it emits an unbindable three-argument date_part(...). Synthesize
+# that shape by injecting a trailing string literal argument. A plain TIMESTAMP is used
+# (rather than TIMESTAMPTZ, which would pull in the icu extension) because the drop is
+# type-agnostic: any trailing value argument reaches children.resize(1) the same way.
+
+statement ok
+SET VARIABLE plan_unix_tz = (
+    SELECT replace(
+        replace(json, '"enum":"second"', '"enum":"unix_time"'),
+        '{"value":{"selection":{"directReference":{"structField":{}},"rootReference":{}}}}',
+        '{"value":{"selection":{"directReference":{"structField":{}},"rootReference":{}}}},{"value":{"literal":{"string":"UTC"}}}'
+    )
+    FROM get_substrait_json('SELECT extract(second FROM ts) AS r FROM t')
+);
+
+query I
+SELECT * FROM from_substrait_json(getvariable('plan_unix_tz')) ORDER BY 1
+----
+-1
+0
+1
+1627991984


### PR DESCRIPTION
The Substrait standard defines `extract` with a `component` enum whose only numeric date/timestamp difference is **`UNIX_TIME`** (the number of seconds elapsed since `1970-01-01 00:00:00 UTC`) returned as `i64` (see `functions_datetime.yaml`).

The DuckDB extension does not support `extract(UNIX_TIME)`. In `SubstraitToDuckDB` (`src/from_substrait.cpp`), because the `extract` branch runs every specifier through `VerifyCorrectExtractSubfield`, which checks membership in `valid_extract_subfields`, a set that does not include `UNIX_TIME`, and DuckDB has no `date_part` specifier of that name. So:

- In debug builds, `VerifyCorrectExtractSubfield`'s `D_ASSERT(...count(subfield))` fires.
- In release builds the assert is compiled out, so the transform builds `date_part('UNIX_TIME', <expr>)`, which DuckDB rejects at binding.

### Fix

Special-case `UNIX_TIME` in the `extract` branch of `SubstraitToDuckDB::TransformScalarFunctionExpr` (`src/from_substrait.cpp`): map it to DuckDB's `date_part('epoch', <expr>)`, which yields the epoch seconds as `DOUBLE`, and wrap the result in a cast to `BIGINT` to honor the standard's `i64` return type.

```cpp
if (subfield == "UNIX_TIME") {
    children.insert(children.begin(), make_uniq<ConstantExpression>(Value("epoch")));
    auto call = make_uniq<FunctionExpression>("date_part", std::move(children));
    return make_uniq<CastExpression>(LogicalType::BIGINT, std::move(call));
}
```

All other `extract` specifiers are unchanged — they continue through `VerifyCorrectExtractSubfield` and the normal `date_part` path. Only the previously-unhandled `UNIX_TIME` specifier is affected.

### Testing

Full build against DuckDB v1.5.5, with both test suites green and no regressions:

- **C unit tests** (`test_substrait_exe`): 261 assertions / 50 cases pass.
- **SQL suite** (`test/*`): 1501 assertions / 53 cases pass, including `test_substrait_extract.test` which exercises the `extract` path.