### PR TITLE
fix: emit TIMESTAMPTZ constants as precision_timestamp_tz literals

### DIFF
--- a/src/include/to_substrait.hpp
+++ b/src/include/to_substrait.hpp
@@ -108,6 +108,7 @@ private:
 	static void TransformTime(const Value &dval, substrait::Expression &sexpr);
 	static void TransformInterval(const Value &dval, substrait::Expression &sexpr);
 	static void TransformTimestamp(const Value &dval, substrait::Expression &sexpr);
+	static void TransformTimestampTz(const Value &dval, substrait::Expression &sexpr);
 	static void TransformEnum(const Value &dval, substrait::Expression &sexpr);
 
 	//! Methods to transform a DuckDB Expression to a Substrait Expression

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -196,6 +196,13 @@ void DuckDBToSubstrait::TransformTimestamp(const Value &dval, substrait::Express
 	sval.set_string(dval.ToString());
 }
 
+void DuckDBToSubstrait::TransformTimestampTz(const Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	auto precision_timestamp_tz = sval.mutable_precision_timestamp_tz();
+	precision_timestamp_tz->set_precision(6); // microseconds
+	precision_timestamp_tz->set_value(dval.GetValueUnsafe<timestamp_tz_t>().value);
+}
+
 void DuckDBToSubstrait::TransformInterval(const Value &dval, substrait::Expression &sexpr) {
 	// Substrait supports two types of INTERVAL (interval_year and interval_day)
 	// whereas DuckDB INTERVAL combines both in one type. Therefore intervals
@@ -275,6 +282,9 @@ void DuckDBToSubstrait::TransformConstant(const Value &dval, substrait::Expressi
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP:
 		TransformTimestamp(dval, sexpr);
+		break;
+	case LogicalTypeId::TIMESTAMP_TZ:
+		TransformTimestampTz(dval, sexpr);
 		break;
 	case LogicalTypeId::INTERVAL:
 		TransformInterval(dval, sexpr);

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -197,10 +197,16 @@ void DuckDBToSubstrait::TransformTimestamp(const Value &dval, substrait::Express
 }
 
 void DuckDBToSubstrait::TransformTimestampTz(const Value &dval, substrait::Expression &sexpr) {
+	auto tz_value = dval.GetValue<timestamp_tz_t>();
+	if (!Value::IsFinite(tz_value)) {
+		// DuckDB encodes +/-infinity as INT64_MAX/MIN micros. Emitting that raw would look
+		// like a real instant near year 294241 to any other consumer, so fail loudly instead.
+		throw NotImplementedException("Substrait has no representation for infinite TIMESTAMPTZ values");
+	}
 	auto &sval = *sexpr.mutable_literal();
 	auto precision_timestamp_tz = sval.mutable_precision_timestamp_tz();
 	precision_timestamp_tz->set_precision(6); // microseconds
-	precision_timestamp_tz->set_value(dval.GetValueUnsafe<timestamp_tz_t>().value);
+	precision_timestamp_tz->set_value(tz_value.value);
 }
 
 void DuckDBToSubstrait::TransformInterval(const Value &dval, substrait::Expression &sexpr) {

--- a/test/sql/test_substrait_types.test
+++ b/test/sql/test_substrait_types.test
@@ -148,6 +148,15 @@ INSERT INTO timestz VALUES ('2021-11-26 10:15:13.123456+00');
 statement ok
 CALL get_substrait('SELECT s FROM timestz WHERE s > ''2001-11-26 05:02:23.123456+00'' ');
 
+# With rows straddling the constant the filter is selective and cannot be
+# folded away, so the TIMESTAMPTZ literal survives into the plan and the
+# producer must emit it as a precision_timestamp_tz literal.
+statement ok
+INSERT INTO timestz VALUES ('1999-01-01 00:00:00+00');
+
+statement ok
+CALL get_substrait('SELECT s FROM timestz WHERE s > ''2001-11-26 05:02:23.123456+00'' ');
+
 # not supported because TIMETZ comparisons generate a UBIGINT
 mode skip
 


### PR DESCRIPTION
The Substrait producer (`DuckDBToSubstrait::TransformConstant`, `src/to_substrait.cpp`) has no case for `LogicalTypeId::TIMESTAMP_TZ`, so any `TIMESTAMPTZ` literal that reaches the producer falls through to the `default:` branch and throws:

```
Not implemented Error: Consuming a value of type TIMESTAMP WITH TIME ZONE is not supported yet
```

### Fix

Add a `TransformTimestampTz` that emits a typed `precision_timestamp_tz` literal — mirroring the existing `TransformTime` (`precision_time`) path — and wire it into the `TransformConstant` switch. The value is the raw microsecond count from the `timestamp_tz_t`, with precision `6` (microseconds), which is exactly what the consumer's `kPrecisionTimestampTz` branch reads back via `ScaleToMicros`.

```cpp
void DuckDBToSubstrait::TransformTimestampTz(const Value &dval, substrait::Expression &sexpr) {
    auto &sval = *sexpr.mutable_literal();
    auto precision_timestamp_tz = sval.mutable_precision_timestamp_tz();
    precision_timestamp_tz->set_precision(6); // microseconds
    precision_timestamp_tz->set_value(dval.GetValueUnsafe<timestamp_tz_t>().value);
}
```

```cpp
case LogicalTypeId::TIMESTAMP_TZ:
    TransformTimestampTz(dval, sexpr);
    break;
```

No other constant path changes; only the previously-unhandled `TIMESTAMP_TZ` id is affected.

### Testing

The regression test in `test/sql/test_substrait_types.test` adds a second row that straddles the filter constant, so the filter stays selective and cannot be folded — forcing the `TIMESTAMPTZ` literal into the plan and exercising the new producer path (with round-trip verification via `PRAGMA enable_verification`).

Full build against DuckDB v1.5.5, both suites green with no regressions:

- **SQL suite** (`test/*`): 1503 assertions / 53 cases pass (1 skipped: `require httpfs`).
- **C unit tests** (`test_substrait_exe`): 261 assertions / 50 cases pass.