### PR TITLE
fix: honor emit mappings beyond ProjectRel

### DIFF
--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -975,6 +975,9 @@ shared_ptr<Relation> SubstraitToDuckDB::TransformLateralJoinOp(const substrait::
 		left_column_count = left_rel->Columns().size();
 
 		auto &filter_rel = slateral.right().filter();
+		if (filter_rel.common().has_emit()) {
+			throw NotImplementedException("emit on the right-side FilterRel of a LateralJoinRel is not supported");
+		}
 		auto &filter_condition = filter_rel.condition();
 		// Transform the filter condition; field indices will be relative to the right side
 		correlated_filter_condition = TransformExpr(filter_condition);
@@ -1156,7 +1159,11 @@ const google::protobuf::RepeatedField<int32_t> &GetOutputMapping(const substrait
 		static google::protobuf::RepeatedField<int32_t> empty_mapping;
 		return empty_mapping;
 	}
-	return common->emit().output_mapping();
+	const auto &mapping = common->emit().output_mapping();
+	if (mapping.empty()) {
+		throw NotImplementedException("An empty emit mapping (zero output columns) is not supported");
+	}
+	return mapping;
 }
 
 shared_ptr<Relation>
@@ -1171,7 +1178,7 @@ SubstraitToDuckDB::TransformProjectOp(const substrait::Rel &sop,
 	size_t num_input_columns = 0;
 	if (sop.project().input().rel_type_case() == substrait::Rel::RelTypeCase::kRead) {
 		auto &sget = sop.project().input().read();
-		if (sget.has_virtual_table()) {
+		if (sget.has_virtual_table() && !sget.common().has_emit()) {
 			auto virtual_table = sget.virtual_table();
 			if ((virtual_table.expressions().empty()) ||
 			    (virtual_table.expressions().size() > 0 && virtual_table.expressions(0).fields().empty())) {
@@ -1197,6 +1204,9 @@ SubstraitToDuckDB::TransformProjectOp(const substrait::Rel &sop,
 	} else {
 		expressions.resize(mapping.size());
 		for (size_t i = 0; i < mapping.size(); i++) {
+			if (mapping[i] < 0) {
+				throw InvalidInputException("Project emit mapping index must be non-negative, got %d", mapping[i]);
+			}
 			if (mapping[i] < num_input_columns) {
 				expressions[i] = make_uniq<PositionalReferenceExpression>(mapping[i] + 1);
 			} else {
@@ -1789,29 +1799,41 @@ shared_ptr<Relation> SubstraitToDuckDB::TransformReferenceOp(const substrait::Re
 
 shared_ptr<Relation> SubstraitToDuckDB::TransformOp(const substrait::Rel &sop,
                                                     const google::protobuf::RepeatedPtrField<std::string> *names) {
+	shared_ptr<Relation> result;
 	switch (sop.rel_type_case()) {
 	case substrait::Rel::RelTypeCase::kJoin:
-		return TransformJoinOp(sop);
+		result = TransformJoinOp(sop);
+		break;
 	case substrait::Rel::RelTypeCase::kLateralJoin:
-		return TransformLateralJoinOp(sop);
+		result = TransformLateralJoinOp(sop);
+		break;
 	case substrait::Rel::RelTypeCase::kCross:
-		return TransformCrossProductOp(sop);
+		result = TransformCrossProductOp(sop);
+		break;
 	case substrait::Rel::RelTypeCase::kFetch:
-		return TransformFetchOp(sop, names);
+		result = TransformFetchOp(sop, names);
+		break;
 	case substrait::Rel::RelTypeCase::kFilter:
-		return TransformFilterOp(sop);
+		result = TransformFilterOp(sop);
+		break;
 	case substrait::Rel::RelTypeCase::kProject:
+		// Project applies emit while selecting its input columns and expressions.
 		return TransformProjectOp(sop, names);
 	case substrait::Rel::RelTypeCase::kAggregate:
-		return TransformAggregateOp(sop);
+		result = TransformAggregateOp(sop);
+		break;
 	case substrait::Rel::RelTypeCase::kRead:
-		return TransformReadOp(sop);
+		result = TransformReadOp(sop);
+		break;
 	case substrait::Rel::RelTypeCase::kSort:
-		return TransformSortOp(sop, names);
+		result = TransformSortOp(sop, names);
+		break;
 	case substrait::Rel::RelTypeCase::kWindow:
-		return TransformWindowOp(sop);
+		result = TransformWindowOp(sop);
+		break;
 	case substrait::Rel::RelTypeCase::kSet:
-		return TransformSetOp(sop, names);
+		result = TransformSetOp(sop, names);
+		break;
 	case substrait::Rel::RelTypeCase::kWrite:
 		return TransformWriteOp(sop);
 	case substrait::Rel::RelTypeCase::kReference:
@@ -1820,6 +1842,23 @@ shared_ptr<Relation> SubstraitToDuckDB::TransformOp(const substrait::Rel &sop,
 		throw NotImplementedException("Unsupported relation type %s",
 		                              string(substrait::Rel::GetDescriptor()->FindFieldByNumber(sop.rel_type_case())->name()));
 	}
+
+	const auto &mapping = GetOutputMapping(sop);
+	if (mapping.empty()) {
+		return result;
+	}
+	const auto column_count = result->Columns().size();
+	vector<unique_ptr<ParsedExpression>> expressions;
+	vector<string> aliases;
+	for (auto index : mapping) {
+		if (index < 0 || static_cast<idx_t>(index) >= column_count) {
+			throw InvalidInputException("Relation emit mapping index %d is out of range for %llu output columns", index,
+			                            static_cast<unsigned long long>(column_count));
+		}
+		expressions.push_back(make_uniq<PositionalReferenceExpression>(static_cast<idx_t>(index) + 1));
+		aliases.push_back("expr_" + to_string(aliases.size()));
+	}
+	return make_shared_ptr<ProjectionRelation>(std::move(result), std::move(expressions), std::move(aliases));
 }
 
 void SkipColumnNamesRecurse(int32_t &columns_to_skip, const LogicalType &type) {

--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -1768,19 +1768,22 @@ shared_ptr<Relation> SubstraitToDuckDB::TransformWriteOp(const substrait::Rel &s
 	case substrait::WriteRel::WriteOp::WriteRel_WriteOp_WRITE_OP_INSERT:
 		return input->InsertRel(schema_name, table_name);
 	case substrait::WriteRel::WriteOp::WriteRel_WriteOp_WRITE_OP_DELETE: {
-		switch (input->type) {
-		case RelationType::PROJECTION_RELATION: {
-			auto project = std::move(input.get()->Cast<ProjectionRelation>());
-			auto filter = std::move(project.child->Cast<FilterRelation>());
-                        return make_shared_ptr<DeleteRelation>(filter.context, std::move(filter.condition), catalog_name, schema_name, table_name);
+		// Read projection and emit can add several projections above the row predicate.
+		auto delete_input = input.get();
+		while (delete_input->type == RelationType::PROJECTION_RELATION) {
+			delete_input = delete_input->Cast<ProjectionRelation>().child.get();
 		}
-		case RelationType::FILTER_RELATION: {
-			auto filter = std::move(input.get()->Cast<FilterRelation>());
-			return make_shared_ptr<DeleteRelation>(filter.context, std::move(filter.condition), catalog_name, schema_name, table_name);
-		}
-		default:
+		if (delete_input->type != RelationType::FILTER_RELATION) {
 			throw NotImplementedException("Unsupported relation type for delete operation");
 		}
+		auto &filter = delete_input->Cast<FilterRelation>();
+		// DeleteRelation binds the predicate directly against the target table. A predicate
+		// over projected or filtered input cannot be reused without translating its meaning.
+		if (filter.child->type != RelationType::TABLE_RELATION && filter.child->type != RelationType::VIEW_RELATION) {
+			throw NotImplementedException("Unsupported relation type for delete operation");
+		}
+		return make_shared_ptr<DeleteRelation>(filter.context, std::move(filter.condition), catalog_name, schema_name,
+		                                      table_name);
 	}
 	default:
 		throw NotImplementedException("Unsupported write operation %s",

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(yaml-cpp REQUIRED)
 # definitions the generated function registry was built from.
 find_package(SubstraitExtensions CONFIG REQUIRED)
 
-set(ALL_SOURCES test_substrait_c_api.cpp test_substrait_c_utils.cpp test_projection.cpp test_base_schema_projection.cpp test_root_names.cpp test_dialect_validation.cpp)
+set(ALL_SOURCES test_substrait_c_api.cpp test_substrait_c_utils.cpp test_projection.cpp test_base_schema_projection.cpp test_root_names.cpp test_dialect_validation.cpp test_rel_common_emit.cpp)
 
 
 add_library_unity(test_substrait OBJECT ${ALL_SOURCES})

--- a/test/c/test_rel_common_emit.cpp
+++ b/test/c/test_rel_common_emit.cpp
@@ -104,6 +104,61 @@ TEST_CASE("RelCommon emit reorders, omits and duplicates relation outputs", "[su
 	}
 }
 
+TEST_CASE("Delete preserves its predicate through emitted projections", "[substrait-api][emit][emit-delete]") {
+	for (const string kind : {"read", "filter", "project"}) {
+		DYNAMIC_SECTION(kind) {
+			DuckDB db(nullptr);
+			Connection con(db);
+			CreateEmployeeTable(con);
+			auto plan = EmitJSON::parse(GetSubstraitJSON(con, "DELETE FROM employees WHERE salary < 80000"));
+			auto &input = plan["relations"][0]["root"]["input"]["write"]["input"];
+			if (kind == "filter") {
+				auto condition = input["read"]["filter"];
+				input["read"].erase("filter");
+				input["read"].erase("projection");
+				input = {{"filter", {{"input", input}, {"condition", condition}}}};
+			} else {
+				input["read"]["common"]["emit"]["outputMapping"] = {0};
+				if (kind == "project") {
+					input = {{"project", {{"input", input}, {"expressions", {EmitField(0)}}}}};
+				}
+			}
+			input[kind]["common"]["emit"]["outputMapping"] = {0, 0};
+			auto deleted = FromSubstraitJSON(con, plan.dump());
+			REQUIRE_NO_FAIL(*deleted);
+			auto remaining = con.Query("SELECT employee_id FROM employees ORDER BY employee_id");
+			REQUIRE_NO_FAIL(*remaining);
+			REQUIRE(CHECK_COLUMN(remaining, 0, {1, 2, 4}));
+		}
+	}
+}
+
+TEST_CASE("Delete rejects emitted inputs without a usable table predicate", "[substrait-api][emit][emit-delete]") {
+	for (const string kind : {"no filter", "filter above emit"}) {
+		DYNAMIC_SECTION(kind) {
+			DuckDB db(nullptr);
+			Connection con(db);
+			CreateEmployeeTable(con);
+			auto plan = EmitJSON::parse(GetSubstraitJSON(con, "DELETE FROM employees WHERE salary < 80000"));
+			auto &input = plan["relations"][0]["root"]["input"]["write"]["input"];
+			auto condition = input["read"]["filter"];
+			input["read"].erase("filter");
+			input["read"].erase("projection");
+			input["read"]["common"]["emit"]["outputMapping"] = {3, 0};
+			if (kind == "filter above emit") {
+				// The predicate now addresses salary at emitted position 0, not table position 3.
+				condition["scalarFunction"]["arguments"][0]["value"] = EmitField(0);
+				input = {{"filter", {{"input", input}, {"condition", condition}}}};
+			}
+			CHECK_THROWS_WITH(FromSubstraitJSON(con, plan.dump()),
+			                  Catch::Matchers::Contains("Unsupported relation type for delete operation"));
+			auto remaining = con.Query("SELECT employee_id FROM employees ORDER BY employee_id");
+			REQUIRE_NO_FAIL(*remaining);
+			REQUIRE(CHECK_COLUMN(remaining, 0, {1, 2, 3, 4, 5}));
+		}
+	}
+}
+
 TEST_CASE("RelCommon emit preserves direct and omitted mappings", "[substrait-api][emit]") {
 	DuckDB db(nullptr);
 	Connection con(db);

--- a/test/c/test_rel_common_emit.cpp
+++ b/test/c/test_rel_common_emit.cpp
@@ -1,0 +1,271 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "test_substrait_c_utils.hpp"
+#include <nlohmann/json.hpp>
+
+using namespace duckdb;
+
+namespace {
+using EmitJSON = nlohmann::json;
+
+EmitJSON EmitField(int index) {
+	return {{"selection",
+	         {{"directReference", {{"structField", {{"field", index}}}}}, {"rootReference", EmitJSON::object()}}}};
+}
+
+EmitJSON EmitRead() {
+	return EmitJSON::parse(R"({"read": {
+		"baseSchema": {"names": ["number", "text", "flag"], "struct": {
+			"types": [{"i64": {"nullability": "NULLABILITY_REQUIRED"}},
+			          {"string": {"nullability": "NULLABILITY_REQUIRED"}},
+			          {"bool": {"nullability": "NULLABILITY_REQUIRED"}}],
+			"nullability": "NULLABILITY_REQUIRED"}},
+		"virtualTable": {"expressions": [{"fields": [
+			{"literal": {"i64": "10"}}, {"literal": {"string": "x"}},
+			{"literal": {"boolean": true}}]}]}
+	}})");
+}
+
+EmitJSON EmitRelation(const string &kind) {
+	auto input = EmitRead();
+	if (kind == "read") {
+		return input;
+	}
+	EmitJSON op = {{"input", input}};
+	if (kind == "filter") {
+		op["condition"] = EmitField(2);
+	} else if (kind == "sort") {
+		op["sorts"] = {{{"expr", EmitField(0)}, {"direction", "SORT_DIRECTION_ASC_NULLS_LAST"}}};
+	} else if (kind == "fetch") {
+		op["countExpr"] = {{"literal", {{"i64", "1"}}}};
+	} else if (kind == "aggregate") {
+		op["groupingExpressions"] = {EmitField(0), EmitField(1), EmitField(2)};
+		op["groupings"] = {{{"expressionReferences", {0, 1, 2}}}};
+	} else if (kind == "project") {
+		op["expressions"] = {EmitField(1)};
+	} else if (kind == "set") {
+		op = {{"inputs", {input, input}}, {"op", "SET_OP_UNION_ALL"}};
+	} else if (kind == "window") {
+		op["windowFunctions"] = {{{"functionReference", 2},
+		                          {"outputType", {{"i64", {{"nullability", "NULLABILITY_REQUIRED"}}}}},
+		                          {"boundsType", "BOUNDS_TYPE_ROWS"},
+		                          {"lowerBound", {{"unbounded", EmitJSON::object()}}},
+		                          {"upperBound", {{"unbounded", EmitJSON::object()}}}}};
+	} else {
+		op = {{"left", input}, {"right", input}};
+		if (kind != "cross") {
+			op["expression"] = {{"literal", {{"boolean", true}}}};
+			op["type"] = "JOIN_TYPE_INNER";
+		}
+	}
+	return {{kind, op}};
+}
+
+EmitJSON EmitPlan(const EmitJSON &rel, const EmitJSON &names) {
+	return {{"relations", {{{"root", {{"input", rel}, {"names", names}}}}}},
+	        {"extensions",
+	         {{{"extensionFunction", {{"functionAnchor", 1}, {"name", "count"}}}},
+	          {{"extensionFunction", {{"functionAnchor", 2}, {"name", "row_number"}}}}}},
+	        {"version", {{"minorNumber", 98}}}};
+}
+
+void CheckEmitColumns(Connection &con, const EmitJSON &rel, const duckdb::vector<LogicalType> &types,
+                      const duckdb::vector<duckdb::vector<Value>> &columns) {
+	EmitJSON names = EmitJSON::array();
+	duckdb::vector<string> expected_names;
+	for (idx_t i = 0; i < types.size(); i++) {
+		expected_names.push_back("output_" + to_string(i));
+		names.push_back(expected_names.back());
+	}
+	auto result = FromSubstraitJSON(con, EmitPlan(rel, names).dump());
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->names == expected_names);
+	REQUIRE(result->types == types);
+	for (idx_t i = 0; i < columns.size(); i++) {
+		REQUIRE(CHECK_COLUMN(result, i, columns[i]));
+	}
+}
+} // namespace
+
+TEST_CASE("RelCommon emit reorders, omits and duplicates relation outputs", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	for (const string kind :
+	     {"read", "filter", "sort", "fetch", "join", "aggregate", "cross", "set", "window", "lateralJoin", "project"}) {
+		DYNAMIC_SECTION(kind) {
+			auto rel = EmitRelation(kind);
+			rel[kind]["common"]["emit"]["outputMapping"] = {2, 0, 2};
+			idx_t rows = kind == "set" ? 2 : 1;
+			CheckEmitColumns(con, rel, {LogicalType::BOOLEAN, LogicalType::BIGINT, LogicalType::BOOLEAN},
+			                 {duckdb::vector<Value>(rows, Value::BOOLEAN(true)),
+			                  duckdb::vector<Value>(rows, Value::BIGINT(10)),
+			                  duckdb::vector<Value>(rows, Value::BOOLEAN(true))});
+		}
+	}
+}
+
+TEST_CASE("RelCommon emit preserves direct and omitted mappings", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	for (const auto common : {EmitJSON(), EmitJSON::object(), EmitJSON::parse(R"({"direct": {}})")}) {
+		DYNAMIC_SECTION(common.dump()) {
+			auto rel = EmitRead();
+			if (!common.is_null()) {
+				rel["read"]["common"] = common;
+			}
+			CheckEmitColumns(con, rel, {LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::BOOLEAN},
+			                 {{Value::BIGINT(10)}, {Value("x")}, {Value::BOOLEAN(true)}});
+		}
+	}
+}
+
+TEST_CASE("Read emit follows filtering and read projection", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto rel = EmitRead();
+	rel["read"]["filter"] = EmitField(2);
+	rel["read"]["projection"] = {{"select", {{"structItems", {{{"field", 1}}, {{"field", 2}}}}}},
+	                             {"maintainSingularStruct", true}};
+	rel["read"]["common"]["emit"]["outputMapping"] = {1, 0, 1};
+	CheckEmitColumns(con, rel, {LogicalType::BOOLEAN, LogicalType::VARCHAR, LogicalType::BOOLEAN},
+	                 {{Value::BOOLEAN(true)}, {Value("x")}, {Value::BOOLEAN(true)}});
+}
+
+TEST_CASE("Project indexes input after emit and applies its own mapping once", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto input = EmitRead();
+	input["read"]["common"]["emit"]["outputMapping"] = {2, 0};
+	EmitJSON rel = {
+	    {"project",
+	     {{"input", input}, {"expressions", {EmitField(1)}}, {"common", {{"emit", {{"outputMapping", {2, 0, 2}}}}}}}}};
+	CheckEmitColumns(con, rel, {LogicalType::BIGINT, LogicalType::BOOLEAN, LogicalType::BIGINT},
+	                 {{Value::BIGINT(10)}, {Value::BOOLEAN(true)}, {Value::BIGINT(10)}});
+
+	// A parent mapping must address the already emitted Project output.
+	rel = {
+	    {"filter", {{"input", rel}, {"condition", EmitField(1)}, {"common", {{"emit", {{"outputMapping", {1, 2}}}}}}}}};
+	CheckEmitColumns(con, rel, {LogicalType::BOOLEAN, LogicalType::BIGINT},
+	                 {{Value::BOOLEAN(true)}, {Value::BIGINT(10)}});
+}
+
+TEST_CASE("Emit addresses generated aggregate and window columns", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	for (const string kind : {"aggregate", "window"}) {
+		DYNAMIC_SECTION(kind) {
+			auto rel = EmitRelation(kind);
+			if (kind == "aggregate") {
+				rel[kind]["measures"] = {{{"measure",
+				                           {{"functionReference", 1},
+				                            {"outputType", {{"i64", {{"nullability", "NULLABILITY_REQUIRED"}}}}}}}}};
+			}
+			rel[kind]["common"]["emit"]["outputMapping"] = {3, 0, 3};
+			CheckEmitColumns(con, rel, {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
+			                 {{Value::BIGINT(1)}, {Value::BIGINT(10)}, {Value::BIGINT(1)}});
+		}
+	}
+}
+
+TEST_CASE("Join and cross emit can select either side", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	for (const string kind : {"join", "cross", "lateralJoin"}) {
+		DYNAMIC_SECTION(kind) {
+			auto rel = EmitRelation(kind);
+			rel[kind]["right"]["read"]["virtualTable"]["expressions"][0]["fields"][0]["literal"]["i64"] = "20";
+			rel[kind]["common"]["emit"]["outputMapping"] = {3, 0, 3};
+			CheckEmitColumns(con, rel, {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
+			                 {{Value::BIGINT(20)}, {Value::BIGINT(10)}, {Value::BIGINT(20)}});
+		}
+	}
+}
+
+TEST_CASE("Emit rejects invalid indices and unsupported zero-column outputs", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	for (const string kind : {"read", "project"}) {
+		for (const auto mapping :
+		     {EmitJSON::array(), EmitJSON({-1}), EmitJSON({kind == "read" ? 3 : 4}), EmitJSON({2147483647})}) {
+			DYNAMIC_SECTION(kind << " " << mapping.dump()) {
+				auto rel = EmitRelation(kind);
+				rel[kind]["common"]["emit"]["outputMapping"] = mapping;
+				auto plan = EmitPlan(rel, mapping.empty() ? EmitJSON::array() : EmitJSON({"output"})).dump();
+				REQUIRE_THROWS_WITH(FromSubstraitJSON(con, plan), Catch::Matchers::Contains("emit"));
+				REQUIRE_NO_FAIL(con.Query("SELECT 42"));
+			}
+		}
+	}
+}
+
+TEST_CASE("Filter sort and fetch use columns before their own emit", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto input = EmitRead();
+	auto row = input["read"]["virtualTable"]["expressions"][0];
+	row["fields"][0]["literal"]["i64"] = "20";
+	row["fields"][2]["literal"]["boolean"] = false;
+	input["read"]["virtualTable"]["expressions"].push_back(row);
+	row["fields"][0]["literal"]["i64"] = "30";
+	row["fields"][2]["literal"]["boolean"] = true;
+	input["read"]["virtualTable"]["expressions"].push_back(row);
+
+	EmitJSON rel = {
+	    {"filter",
+	     {{"input", input}, {"condition", EmitField(2)}, {"common", {{"emit", {{"outputMapping", {1, 0}}}}}}}}};
+	rel = {{"sort",
+	        {{"input", rel},
+	         {"sorts", {{{"expr", EmitField(1)}, {"direction", "SORT_DIRECTION_DESC_NULLS_LAST"}}}},
+	         {"common", {{"emit", {{"outputMapping", {1, 0}}}}}}}}};
+	rel = {{"fetch",
+	        {{"input", rel},
+	         {"countExpr", {{"literal", {{"i64", "1"}}}}},
+	         {"offsetExpr", {{"literal", {{"i64", "1"}}}}},
+	         {"common", {{"emit", {{"outputMapping", {1, 0}}}}}}}}};
+	CheckEmitColumns(con, rel, {LogicalType::VARCHAR, LogicalType::BIGINT}, {{Value("x")}, {Value::BIGINT(10)}});
+}
+
+TEST_CASE("Emit keeps an empty read empty with the mapped types", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto rel = EmitRead();
+	rel["read"]["virtualTable"]["expressions"] = EmitJSON::array();
+	rel["read"]["common"]["emit"]["outputMapping"] = {2, 0};
+	CheckEmitColumns(con, rel, {LogicalType::BOOLEAN, LogicalType::BIGINT}, {{}, {}});
+}
+
+TEST_CASE("Emit on a named read follows the declared schema", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE emit_named(extra INTEGER, number BIGINT, text VARCHAR, flag BOOLEAN)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO emit_named VALUES (99, 10, 'x', true)"));
+	auto rel = EmitRead();
+	rel["read"].erase("virtualTable");
+	rel["read"]["namedTable"] = {{"names", {"emit_named"}}};
+	rel["read"]["common"]["emit"]["outputMapping"] = {2, 0};
+	CheckEmitColumns(con, rel, {LogicalType::BOOLEAN, LogicalType::BIGINT},
+	                 {{Value::BOOLEAN(true)}, {Value::BIGINT(10)}});
+}
+
+TEST_CASE("Lateral join does not silently discard its extracted filter emit", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto rel = EmitRelation("lateralJoin");
+	auto right = EmitRelation("filter");
+	right["filter"]["common"]["emit"]["outputMapping"] = {2, 0};
+	rel["lateralJoin"]["right"] = right;
+	auto plan = EmitPlan(rel, {"a", "b", "c", "d", "e"}).dump();
+	REQUIRE_THROWS_WITH(FromSubstraitJSON(con, plan), Catch::Matchers::Contains("right-side FilterRel"));
+}
+
+TEST_CASE("Project does not bypass emit on an empty virtual read", "[substrait-api][emit]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto input = EmitRead();
+	input["read"]["virtualTable"]["expressions"] = EmitJSON::array();
+	input["read"]["common"]["emit"]["outputMapping"] = {2, 0};
+	EmitJSON rel = {
+	    {"project",
+	     {{"input", input}, {"expressions", {EmitField(1)}}, {"common", {{"emit", {{"outputMapping", {2}}}}}}}}};
+	CheckEmitColumns(con, rel, {LogicalType::BIGINT}, {{}});
+}


### PR DESCRIPTION
RelCommon.emit was only applied by ProjectRel. Other relations returned their natural output order, so a mapping such as [2, 0] could silently return the first two columns instead.

Apply the [emit mapping](https://substrait.io/relations/common_fields/#emit) after converting supported query relations, including after ReadRel projection. Use the requested field order and preserve duplicates, and keep ProjectRel's existing mapping path so it is applied once. Add regression coverage for the six reported relation types, Cross, Set, Window and LateralJoin, plus Project composition.

Validate mapping indices and reject explicitly empty mappings, since DuckDB cannot return zero columns. Also reject emit on a right-side FilterRel that the lateral converter extracts into its join condition, where the mapping would otherwise still be lost.

For DELETE, unwrap output projections before reading the filter. Reject inputs whose filter cannot be applied directly to the target table, including a filter over emitted columns. Cover both the remaining rows and rejection without changing the table.

Closes #267
