### PR TITLE
fix: preserve timestamp literal precision

### DIFF
--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -245,9 +245,18 @@ Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 	case substrait::Expression_Literal::LiteralTypeCase::kPrecisionTimestamp: {
 		int64_t timestamp_value = literal.precision_timestamp().value();
 		int32_t precision = literal.precision_timestamp().precision();
-		int64_t micros = ScaleToMicros(timestamp_value, precision);
-		timestamp_t ts(micros);
-		return Value::TIMESTAMP(ts);
+		switch (precision) {
+		case 0:
+			return Value::TIMESTAMPSEC(timestamp_sec_t(timestamp_value));
+		case 3:
+			return Value::TIMESTAMPMS(timestamp_ms_t(timestamp_value));
+		case 6:
+			return Value::TIMESTAMP(timestamp_t(timestamp_value));
+		case 9:
+			return Value::TIMESTAMPNS(timestamp_ns_t(timestamp_value));
+		default:
+			throw NotImplementedException("Unsupported timestamp precision: %d", precision);
+		}
 	}
 	case substrait::Expression_Literal::LiteralTypeCase::kPrecisionTimestampTz: {
 		int64_t timestamp_value = literal.precision_timestamp_tz().value();

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(yaml-cpp REQUIRED)
 # definitions the generated function registry was built from.
 find_package(SubstraitExtensions CONFIG REQUIRED)
 
-set(ALL_SOURCES test_substrait_c_api.cpp test_substrait_c_utils.cpp test_projection.cpp test_base_schema_projection.cpp test_root_names.cpp test_dialect_validation.cpp)
+set(ALL_SOURCES test_substrait_c_api.cpp test_substrait_c_utils.cpp test_projection.cpp test_base_schema_projection.cpp test_root_names.cpp test_dialect_validation.cpp test_timestamp_literals.cpp)
 
 
 add_library_unity(test_substrait OBJECT ${ALL_SOURCES})

--- a/test/c/test_timestamp_literals.cpp
+++ b/test/c/test_timestamp_literals.cpp
@@ -1,0 +1,145 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "test_substrait_c_utils.hpp"
+#include <nlohmann/json.hpp>
+
+using namespace duckdb;
+
+namespace {
+using TimestampJSON = nlohmann::json;
+
+TimestampJSON TimestampLiteral(int precision, int64_t value) {
+	return {{"literal", {{"precisionTimestamp", {{"precision", precision}, {"value", std::to_string(value)}}}}}};
+}
+
+TimestampJSON TimestampRead(int precision, const duckdb::vector<int64_t> &values) {
+	auto fields = TimestampJSON::array();
+	for (auto value : values) {
+		fields.push_back({{"fields", {TimestampLiteral(precision, value)}}});
+	}
+	return {{"read",
+	         {{"baseSchema",
+	           {{"names", {"value"}},
+	            {"struct",
+	             {{"nullability", "NULLABILITY_REQUIRED"},
+	              {"types",
+	               {{{"precisionTimestamp", {{"precision", precision}, {"nullability", "NULLABILITY_REQUIRED"}}}}}}}}}},
+	          {"virtualTable", {{"expressions", fields}}}}}};
+}
+
+TimestampJSON TimestampProject(const TimestampJSON &expression) {
+	auto input = TimestampJSON::parse(R"({"read": {
+		"baseSchema": {"struct": {"nullability": "NULLABILITY_REQUIRED"}},
+		"virtualTable": {"expressions": [{}]}
+	}})");
+	return {{"project", {{"input", input}, {"expressions", {expression}}}}};
+}
+
+TimestampJSON TimestampPlan(const TimestampJSON &rel) {
+	return {{"relations", {{{"root", {{"input", rel}, {"names", {"value"}}}}}}},
+	        {"extensions", {{{"extensionFunction", {{"functionAnchor", 1}, {"name", "equal"}}}}}},
+	        {"version", {{"minorNumber", 98}}}};
+}
+
+void CheckTimestampResult(Connection &con, const TimestampJSON &rel, const LogicalType &type,
+                          const duckdb::vector<int64_t> &values) {
+	auto result = FromSubstraitJSON(con, TimestampPlan(rel).dump());
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->types == duckdb::vector<LogicalType> {type});
+	idx_t row = 0;
+	while (auto chunk = result->Fetch()) {
+		for (idx_t i = 0; i < chunk->size(); i++) {
+			REQUIRE(row < values.size());
+			const auto value = chunk->GetValue(0, i);
+			REQUIRE_FALSE(value.IsNull());
+			// Inspect the stored units without a timestamp cast that could hide a precision loss.
+			REQUIRE(value.GetValueUnsafe<int64_t>() == values[row]);
+			row++;
+		}
+	}
+	REQUIRE(row == values.size());
+}
+} // namespace
+
+TEST_CASE("Timestamp literals preserve precision in virtual tables", "[substrait-api][timestamp-literal]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	const auto index = GENERATE(0, 1, 2, 3);
+	const duckdb::vector<int> precisions {0, 3, 6, 9};
+	const duckdb::vector<LogicalType> types {LogicalType::TIMESTAMP_S, LogicalType::TIMESTAMP_MS,
+	                                         LogicalType::TIMESTAMP, LogicalType::TIMESTAMP_NS};
+	const duckdb::vector<int64_t> values {-1234567891, -1, 0, 1, 1234567891};
+	CAPTURE(precisions[index]);
+	CheckTimestampResult(con, TimestampRead(precisions[index], values), types[index], values);
+	CheckTimestampResult(con, TimestampRead(precisions[index], {}), types[index], {});
+}
+
+TEST_CASE("Timestamp literals preserve precision in projects", "[substrait-api][timestamp-literal]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	const auto value = GENERATE(int64_t(-1234567891), int64_t(-1), int64_t(0), int64_t(1), int64_t(1234567891));
+	CheckTimestampResult(con, TimestampProject(TimestampLiteral(9, value)), LogicalType::TIMESTAMP_NS, {value});
+	// A project over an existing column must retain the appended literal's type as well.
+	TimestampJSON project = {{"project",
+	                          {{"input", TimestampRead(9, {0})},
+	                           {"expressions", {TimestampLiteral(9, value)}},
+	                           {"common", {{"emit", {{"outputMapping", {1}}}}}}}}};
+	CheckTimestampResult(con, project, LogicalType::TIMESTAMP_NS, {value});
+}
+
+TEST_CASE("Timestamp literals distinguish nanoseconds in filters", "[substrait-api][timestamp-literal]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	const auto value = GENERATE(int64_t(-1234567891), int64_t(-1), int64_t(1), int64_t(1234567891));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE timestamps(value TIMESTAMP_NS)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO timestamps VALUES (make_timestamp_ns(" + std::to_string(value) +
+	                          ")), (make_timestamp_ns(" + std::to_string(value + 1) + "))"));
+	auto input = TimestampRead(9, {});
+	input["read"].erase("virtualTable");
+	input["read"]["namedTable"] = {{"names", {"timestamps"}}};
+	TimestampJSON selection = {
+	    {"selection",
+	     {{"directReference", {{"structField", {{"field", 0}}}}}, {"rootReference", TimestampJSON::object()}}}};
+	TimestampJSON condition = {{"scalarFunction",
+	                            {{"functionReference", 1},
+	                             {"outputType", {{"bool", {{"nullability", "NULLABILITY_REQUIRED"}}}}},
+	                             {"arguments", {{{"value", selection}}, {{"value", TimestampLiteral(9, value)}}}}}}};
+	CheckTimestampResult(con, {{"filter", {{"input", input}, {"condition", condition}}}}, LogicalType::TIMESTAMP_NS,
+	                     {value});
+}
+
+TEST_CASE("Timestamp precision survives nested literals", "[substrait-api][timestamp-literal]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	TimestampJSON literal = {
+	    {"literal",
+	     {{"list", {{"values", {TimestampLiteral(9, -1)["literal"], TimestampLiteral(9, 1234567891)["literal"]}}}}}}};
+	auto result = FromSubstraitJSON(con, TimestampPlan(TimestampProject(literal)).dump());
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->types == duckdb::vector<LogicalType> {LogicalType::LIST(LogicalType::TIMESTAMP_NS)});
+	auto chunk = result->Fetch();
+	REQUIRE(chunk);
+	REQUIRE(chunk->size() == 1);
+	const auto value = chunk->GetValue(0, 0);
+	const auto &children = ListValue::GetChildren(value);
+	REQUIRE(children.size() == 2);
+	REQUIRE_FALSE(children[0].IsNull());
+	REQUIRE_FALSE(children[1].IsNull());
+	REQUIRE(children[0].GetValueUnsafe<int64_t>() == -1);
+	REQUIRE(children[1].GetValueUnsafe<int64_t>() == 1234567891);
+}
+
+TEST_CASE("Unsupported timestamp literal precisions match schema errors", "[substrait-api][timestamp-literal]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	const auto precision = GENERATE(-1, 1, 2, 4, 5, 7, 8, 10, 12);
+	const auto message = "Unsupported timestamp precision: " + std::to_string(precision);
+	REQUIRE_THROWS_WITH(FromSubstraitJSON(con, TimestampPlan(TimestampRead(precision, {})).dump()),
+	                    Catch::Matchers::Contains(message));
+	REQUIRE_THROWS_WITH(FromSubstraitJSON(con, TimestampPlan(TimestampRead(precision, {1234567891})).dump()),
+	                    Catch::Matchers::Contains(message));
+	REQUIRE_THROWS_WITH(
+	    FromSubstraitJSON(con, TimestampPlan(TimestampProject(TimestampLiteral(precision, 1234567891))).dump()),
+	    Catch::Matchers::Contains(message));
+	REQUIRE_NO_FAIL(con.Query("SELECT 42"));
+}

--- a/test/sql/test_literals.test
+++ b/test/sql/test_literals.test
@@ -247,11 +247,11 @@ CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go
 ----
 [NULL, 10, 20]
 
-# out-of-range precision (precision > 9 should throw)
+# unsupported timestamp precision
 statement error
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"precision_timestamp":{"precision":10, "value":99999999}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Invalid Input Error: Precision must be between 0 and 9, got 10
+Not implemented Error: Unsupported timestamp precision: 10
 
 # user defined
 statement error


### PR DESCRIPTION
A precision_timestamp literal was always converted to microseconds. At precision 9 this dropped the last three digits and returned TIMESTAMP instead of TIMESTAMP_NS. An empty virtual read with the same declared type already returned TIMESTAMP_NS.

Construct timestamp values in their [declared units](https://github.com/substrait-io/substrait/blob/v0.98.0/proto/substrait/algebra.proto#L1151-L1155) for the supported precisions 0, 3, 6, and 9. Now reject other precisions with the same error as type conversion, including 1, 2, 4, 5, 7, and 8, which were previously accepted and converted to microseconds. Keep precision_timestamp_tz handling unchanged.

Add regression coverage for exact types and values in populated and empty virtual reads, projects, nanosecond-sensitive filters, and nested list literals, including negative values and unsupported precisions.

Closes #268
